### PR TITLE
[QA]  Implicit wait after sending context notifications

### DIFF
--- a/tests/acceptance/commons/constants.py
+++ b/tests/acceptance/commons/constants.py
@@ -51,3 +51,6 @@ ATTRIBUTES_VALUE = u'contextValue'
 
 # Configuration constants
 FACTS_DEFAULT_WINDOW_SIZE = 2
+
+# Test constants
+IMPLICIT_WAIT_AFTER_NOTIFICATION = 1  # Seconds.

--- a/tests/acceptance/features/component/steps/context_update.py
+++ b/tests/acceptance/features/component/steps/context_update.py
@@ -84,7 +84,6 @@ def a_context_update_is_received(context, server_id):
 
     send_context_notification_step_helper(context, context.tenant_id_facts, server_id)
 
-    #
     # Implicit Wait. We need to wait for facts processing after sending context notifications.
     time.sleep(IMPLICIT_WAIT_AFTER_NOTIFICATION)
 

--- a/tests/acceptance/features/component/steps/context_update.py
+++ b/tests/acceptance/features/component/steps/context_update.py
@@ -28,6 +28,8 @@ from behave import step
 from hamcrest import assert_that, is_
 from qautils.dataset.dataset_utils import DatasetUtils
 from commons.step_helpers import send_context_notification_step_helper
+from commons.constants import IMPLICIT_WAIT_AFTER_NOTIFICATION
+import time
 
 behave.use_step_matcher("re")
 _dataset_utils = DatasetUtils()
@@ -81,6 +83,10 @@ def the_context_notification_has_these_context_elements(context):
 def a_context_update_is_received(context, server_id):
 
     send_context_notification_step_helper(context, context.tenant_id_facts, server_id)
+
+    #
+    # Implicit Wait. We need to wait for facts processing after sending context notifications.
+    time.sleep(IMPLICIT_WAIT_AFTER_NOTIFICATION)
 
 
 @step(u'the context is updated')


### PR DESCRIPTION
#### Reviewers
@flopezag 

#### Description
We need a implicit wait after sending context notifications to fiware-facts in order to leave it process the requests. Some tests occasionally fails because of that.

#### Testing
Jenkins.