### PR TITLE
Adding try sentence to catch exceptions when a rabbitmq con…

### DIFF
--- a/tests/acceptance/features/component/environment.py
+++ b/tests/acceptance/features/component/environment.py
@@ -140,9 +140,12 @@ def after_scenario(context, scenario):
     for consumer in context.rabbitmq_consumer_list:
         try:
             consumer.stop()
-            consumer.close_connection()
         except Exception:
             __logger__.warn("Rabbitmq consumer was already stopped")
+        try:
+            consumer.close_connection()
+        except Exception:
+            __logger__.warn("Rabbitmq consumer was already closed connection")
 
     # Close RabbitMQ publisher (if initiated)
     context.rabbitmq_publisher.close()

--- a/tests/acceptance/features/component/environment.py
+++ b/tests/acceptance/features/component/environment.py
@@ -138,8 +138,11 @@ def after_scenario(context, scenario):
 
     # Close all RabbitMQ consumers (if initiated)
     for consumer in context.rabbitmq_consumer_list:
-        consumer.stop()
-        consumer.close_connection()
+        try:
+            consumer.stop()
+            consumer.close_connection()
+        except Exception:
+            __logger__.warn("Rabbitmq consumer was already stopped")
 
     # Close RabbitMQ publisher (if initiated)
     context.rabbitmq_publisher.close()


### PR DESCRIPTION
### REVIEWERS
@flopezag 

### DESCRIPTION
- try sentence added to catch exceptions when a rabbitmq consumer was already stopped.
- adding a new try to encapsulate close_connection

### TEST
- this solution was tested in an internal test environment using Jenkins: http://ci-fiware-01.hi.inet/jenkins/job/PolicyManager-Facts-4-Acceptance/