### PR TITLE
Add automatic version renumbering to Bosun - Facts.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,16 @@
+[bumpversion]
+current_version = 2.6.0
+commit = True
+tag = False
+
+[bumpversion:file:sonar-project.properties]
+search = sonar.projectVersion={current_version}
+replace = sonar.projectVersion={new_version}
+
+[bumpversion:file:.gitchangelog.rc]
+search = unreleased_version_label = "v{current_version} (unreleased)"
+replace = unreleased_version_label = "v{new_version} (unreleased)"
+
+[bumpversion:file:./facts/config.py]
+search = __version__ = '{current_version}'
+replace = __version__ = '{new_version}'


### PR DESCRIPTION
#### REVIEWERS
@pratid 

#### DESCRIPTION
Configure bumpversion to renumbering on each release the version of the component.

#### TESTING
Locally through --dry-run option