### PR TITLE
Some debian package manager tweaks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,7 +106,7 @@ Examples:
 .. code::
 
     centos$ sudo yum install mysql-devel
-    ubuntu$ sudo apt-get install mysql-devel
+    ubuntu$ sudo apt-get --no-install-recommends -y install mysql-devel
 
 Top_.
 
@@ -241,7 +241,7 @@ Just install supervisor on your system:
 
 .. code::
 
-    $ sudo apt-get install supervisor
+    $ sudo apt-get --no-install-recommends -y install supervisor
 
 Copy the file ``utils/facts_start`` to ``/etc/fiware.d``.
 Make this script executable:

--- a/docker/AcceptanceTests/Dockerfile
+++ b/docker/AcceptanceTests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu
 RUN apt-get update
-RUN apt-get -y install python-pip python-dev \
+RUN apt-get --no-install-recommends -y install python-pip python-dev \
    libpq-dev netcat libmysqlclient-dev libpq-dev \
    git libffi-dev 
 RUN git clone https://github.com/telefonicaid/fiware-facts /opt/fiware-facts

--- a/docker/AcceptanceTests/Dockerfile
+++ b/docker/AcceptanceTests/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu
 RUN apt-get update
 RUN apt-get --no-install-recommends -y install python-pip python-dev \
    libpq-dev netcat libmysqlclient-dev libpq-dev \
-   git libffi-dev 
+   git libffi-dev apt-utils ca-certificates apt-transport-https
 RUN git clone https://github.com/telefonicaid/fiware-facts /opt/fiware-facts
 WORKDIR /opt/fiware-facts/tests/acceptance
 RUN pip install --upgrade pip

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu
 RUN apt-get update
-RUN apt-get -y install  python-dev \
+RUN apt-get --no-install-recommends -y install  python-dev \
    libpq-dev libmysqlclient-dev libpq-dev \
    git curl netcat libffi-dev zip python-mysqldb \
    supervisor python-clips build-essential gcc

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu
 RUN apt-get update
 RUN apt-get --no-install-recommends -y install  python-dev \
+   apt-utils ca-certificates apt-transport-https \
    libpq-dev libmysqlclient-dev libpq-dev \
    git curl netcat libffi-dev zip python-mysqldb \
    supervisor python-clips build-essential gcc

--- a/docker/UnitTests/Dockerfile
+++ b/docker/UnitTests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu
 RUN apt-get update
-RUN apt-get -y install  python-dev \
+RUN apt-get --no-install-recommends -y install  python-dev \
    libpq-dev libmysqlclient-dev libpq-dev \
    git wget curl libffi-dev zip python-mysqldb \
    supervisor python-clips build-essential gcc

--- a/docker/UnitTests/Dockerfile
+++ b/docker/UnitTests/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu
 RUN apt-get update
 RUN apt-get --no-install-recommends -y install  python-dev \
+   apt-utils ca-certificates apt-transport-https \
    libpq-dev libmysqlclient-dev libpq-dev \
    git wget curl libffi-dev zip python-mysqldb \
    supervisor python-clips build-essential gcc

--- a/tests/acceptance/Vagrantfile
+++ b/tests/acceptance/Vagrantfile
@@ -39,8 +39,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision "shell", inline: "wget https://bootstrap.pypa.io/get-pip.py", privileged: true
   config.vm.provision "shell", inline: "python get-pip.py", privileged: true
   config.vm.provision "shell", inline: "apt-get update", privileged: true
-  config.vm.provision "shell", inline: "apt-get -y install python-dev", privileged: true
-  config.vm.provision "shell", inline: "apt-get -y install git", privileged: true
-  config.vm.provision "shell", inline: "apt-get -y install libxml2-dev libxslt1-dev", privileged: true
+  config.vm.provision "shell", inline: "apt-get --no-install-recommends -y install python-dev", privileged: true
+  config.vm.provision "shell", inline: "apt-get --no-install-recommends -y install git", privileged: true
+  config.vm.provision "shell", inline: "apt-get --no-install-recommends -y install libxml2-dev libxslt1-dev", privileged: true
   config.vm.provision "shell", inline: "pip install -r /vagrant/requirements.txt", privileged: true
 end


### PR DESCRIPTION

By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages . 

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .